### PR TITLE
Make it work with Youtube API v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,23 @@ see [this page for a demo](http://erossignon.github.com/blog/2012/11/22/10-awsom
 
 ## How to install it ?
 
-1. Add ```youtube.rb``` to your ```plugin``` folder
-2. Copy ```_rve.sccs``` to ```/sass/custom```
-3. Add ```@import "custom/rve"``` to  ```/sass/screen.scss```
+1. Add ```gem 'yt'``` to your ```Gemfile``` and run ```Bundle```
+2. Add [your Youtube API key](https://github.com/Fullscreen/yt#apps-that-do-not-require-user-interactions) to your ```_config.yml``` file:
 
-## credits
+    ```
+    youtube
+      api_key: <put your key here>
+    ```
+3. Add ```youtube.rb``` to your ```plugin``` folder
+4. Copy ```_rve.sccs``` to ```/sass/custom```
+5. Add ```@import "custom/rve"``` to  ```/sass/screen.scss```
+
+## Credits
 
 Thanks go to Anders M. Andersen for his [blogpost about responsive embeds](http://amobil.se/2011/11/responsive-embeds/) and to Portway Point for their [Jekyll Youtube Liquid Template Tag Gist](http://www.portwaypoint.co.uk/jekyll-youtube-liquid-template-tag-gist/)
 
-## Edorsement
+Thanks to [Fullscreen](http://www.fullscreen.com/) for [yt](https://github.com/Fullscreen/yt), "The reliable YouTube API Ruby client".
+
+## Endorsement
 
 If you like it feel free to endorse me: [![](http://api.coderwall.com/erossignon/endorsecount.png)](http://coderwall.com/erossignon)

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -29,6 +29,7 @@
 #   
 require 'json'
 require 'erb'
+require 'yt'
 
 class YouTube < Liquid::Tag
   Syntax = /^\s*([^\s]+)(\s+(\d+)\s+(\d+)\s*)?/

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -59,6 +59,14 @@ class YouTube < Liquid::Tag
         return Cache[@id]
     end
 
+    site = context.registers[:site]
+    settings = site.config['youtube']
+    api_key = settings['api_key']
+
+    Yt.configure do |config|
+      config.api_key = api_key
+    end
+
     # extract video information using a REST command 
     response = Net::HTTP.get_response("gdata.youtube.com","/feeds/api/videos/#{@id}?v=2&alt=jsonc")
     data = response.body

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -67,19 +67,11 @@ class YouTube < Liquid::Tag
       config.api_key = api_key
     end
 
-    # extract video information using a REST command 
-    response = Net::HTTP.get_response("gdata.youtube.com","/feeds/api/videos/#{@id}?v=2&alt=jsonc")
-    data = response.body
-    result = JSON.parse(data)
+    video = Yt::Video.new id: @id
 
-    # if the hash has 'Error' as a key, we raise an error
-    if result.has_key? 'Error'
-        puts "web service error or invalid video id"
-    end
-
-    # extract the title and description from the json string
-    @title = result["data"]["title"]
-    @description = result["data"]["description"]
+    # extract the title and description
+    @title = video.title
+    @description = video.description
 
     puts " title #{@title}"
 


### PR DESCRIPTION
The v3 API needs an API key for every call, and is not as easy as the v2.

I used [yt](https://github.com/Fullscreen/yt), a great Ruby Youtube API client, really simple to use and reliable.

It works like that for [my own website](http://nicolas-hoizey.com/).