### PR TITLE
Fixed _config.yml example in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ see [this page for a demo](http://erossignon.github.com/blog/2012/11/22/10-awsom
 
     ```
     youtube:
-    api_key: <put your key here>
+      api_key: <put your key here>
     ```
 3. Add ```youtube.rb``` to your ```plugin``` folder
 4. Copy ```_rve.sccs``` to ```/sass/custom```


### PR DESCRIPTION
I couldn't run `jekyll build` until I fixed this in my _config.yml. The error I was getting was this:

`undefined method `[]' for nil:NilClass`