### PR TITLE
Add a cache to limit calls to the Youtube API to only new videos

### DIFF
--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -84,8 +84,8 @@ class YouTube < Liquid::Tag
       'title' => video.title,
       'description' => video.description
     }
+    Jekyll.logger.info("[Youtube]", "#{@video_data['title']}")
 
-    puts " title #{@title}"
 
     @style = "width:100%;height:100%;background:#000 url(http://i2.ytimg.com/vi/#{@id}/0.jpg) center center no-repeat;background-size:contain;position:absolute" 
     

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -64,7 +64,9 @@ class YouTube < Liquid::Tag
 
     @cache_file = File.join(@cache_folder, @id)
     if (File.exists?(@cache_file))
-      return File.read(@cache_file)
+      result = File.read(@cache_file)
+      Cache[@id] = result
+      return result
     end
 
     site = context.registers[:site]

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -40,7 +40,7 @@ class YouTube < Liquid::Tag
     super
 
     @cache_folder = '.jekyll-cache/youtube'
-    Dir.mkdir(@cache_folder) unless File.exist?(@cache_folder)
+    Dir.mkdir(@cache_folder) unless File.exists?(@cache_folder)
 
     if markup =~ Syntax then
       @id = $1

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -30,6 +30,7 @@
 require 'json'
 require 'erb'
 require 'yt'
+require 'digest'
 
 class YouTube < Liquid::Tag
   Syntax = /^\s*([^\s]+)(\s+(\d+)\s+(\d+)\s*)?/
@@ -62,7 +63,7 @@ class YouTube < Liquid::Tag
         return Cache[@id]
     end
 
-    @cache_file = File.join(@cache_folder, @id)
+    @cache_file = File.join(@cache_folder, Digest::MD5.hexdigest("#{@id}"))
     if (File.exists?(@cache_file))
       result = File.read(@cache_file)
       Cache[@id] = result

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -38,6 +38,9 @@ class YouTube < Liquid::Tag
   def initialize(tagName, markup, tokens)
     super
 
+    @cache_folder = ".jekyll-cache/youtube"
+    Dir.mkdir(@cache_folder) unless File.exist?(@cache_folder)
+
     if markup =~ Syntax then
       @id = $1
 
@@ -57,6 +60,11 @@ class YouTube < Liquid::Tag
 
     if ( Cache.has_key?(@id)) then 
         return Cache[@id]
+    end
+
+    @cache_file = File.join(@cache_folder, @id)
+    if (File.exists?(@cache_file))
+      return File.read(@cache_file)
     end
 
     site = context.registers[:site]
@@ -110,6 +118,11 @@ class YouTube < Liquid::Tag
 EOF
   Cache[@id] = result
   return result
+    # Cache the result in a file
+    File.open($cache_file, "w") do |f|
+      f.write(result)
+    end
+
 
   end
 

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -126,10 +126,6 @@ class YouTube < Liquid::Tag
 EOF
   Cache[@id] = result
   return result
-    # Cache the result in a file
-    File.open($cache_file, "w") do |f|
-      f.write(result)
-    end
 
 
   end

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -1,6 +1,8 @@
-#  (c) Etienne Rossignon 
+#  (c) Etienne Rossignon
 #  Licence : MIT
-#  
+#
+#  https://github.com/erossignon/jekyll-youtube-lazyloading
+#
 #  this liquid plugin insert a embeded youtube video to your octopress or Jekill blog
 #  using the following syntax:
 #    {% youtube ABCDEF123  %}
@@ -8,17 +10,17 @@
 #  this plugin has been designed to optimize loading time when many youtube videos
 #  are inserted to a single page by delaying the youtube <iframe>'s until the user
 #  click on the thumbnail image of the video.
-#  
-#  Special care have been taken to make sure tha the video resizes properly when 
-#  the webbrowser page width changes, or on smartphones. 
-#  
-#   
 #
-#  a jsfiddle to experiment the lazy loading process can be found at : 
+#  Special care have been taken to make sure tha the video resizes properly when
+#  the webbrowser page width changes, or on smartphones.
+#
+#
+#
+#  a jsfiddle to experiment the lazy loading process can be found at :
 #        http://jsfiddle.net/erossignon/3DZ6f
 #
-# credits: 
-#   responsive video : 
+# credits:
+#   responsive video :
 #       https://github.com/optikfluffel/octopress-responsive-video-embed
 #       http://andmag.se/2012/10/responsive-images-lazy-load-and-multiserve-images/
 #   lazy loading:
@@ -26,7 +28,7 @@
 #   jekyll plugin:
 #       http://makokal.github.com/blog/2012/02/24/simple-jekyll-plugin-for-youtube-videos/
 #       https://gist.github.com/1805814
-#   
+#
 require 'json'
 require 'erb'
 require 'yt'
@@ -47,7 +49,7 @@ class YouTube < Liquid::Tag
 
       if $2.nil? then
           @width = 560
-          @height = 315 
+          @height = 315
       else
           @width = $2.to_i
           @height = $3.to_i
@@ -59,11 +61,12 @@ class YouTube < Liquid::Tag
 
   def render(context)
 
-    if ( Cache.has_key?(@id)) then 
+    if (Cache.has_key?(@id)) then
         return Cache[@id]
     end
 
     @cache_file = File.join(@cache_folder, Digest::MD5.hexdigest("#{@id}"))
+
     if (File.exists?(@cache_file))
       @video_data = JSON.parse(File.read(@cache_file))
       Jekyll.logger.info("[Youtube]", "#{@video_data['title']} (cached)")
@@ -96,21 +99,21 @@ class YouTube < Liquid::Tag
     @emu = "https://www.youtube.com/embed/#{@id}?autoplay=1"
 
     @videoFrame =  CGI.escapeHTML("<iframe style=\"vertical-align:top;width:100%;height:100%;position:absolute;\" src=\"#{@emu}\" frameborder=\"0\" allowfullscreen></iframe>")
- 
-    # with jQuery 
-    #@onclick    = "$('##{@id}').replaceWith('#{@videoFrame}');return false;"
- 
-    # without JQuery
-    @onclick    = "var myAnchor = document.getElementById('#{@id}');" + 
-                  "var tmpDiv = document.createElement('div');" +  
-                  "tmpDiv.innerHTML = '#{@videoFrame}';" + 
-                  "myAnchor.parentNode.replaceChild(tmpDiv.firstChild, myAnchor);"+
-                  "return false;" 
 
-   # note: so special care is required to produce html code that will not be massage by the 
+    # with jQuery
+    #@onclick    = "$('##{@id}').replaceWith('#{@videoFrame}');return false;"
+
+    # without JQuery
+    @onclick    = "var myAnchor = document.getElementById('#{@id}');" +
+                  "var tmpDiv = document.createElement('div');" +
+                  "tmpDiv.innerHTML = '#{@videoFrame}';" +
+                  "myAnchor.parentNode.replaceChild(tmpDiv.firstChild, myAnchor);"+
+                  "return false;"
+
+   # note: so special care is required to produce html code that will not be massage by the
    #       markdown processor :
-   #       extract from the markdown doc :  
-   #           'The only restrictions are that block-level HTML elements ¿ e.g. <div>, <table>, <pre>, <p>, etc. 
+   #       extract from the markdown doc :
+   #           'The only restrictions are that block-level HTML elements � e.g. <div>, <table>, <pre>, <p>, etc.
    #            must be separated from surrounding content by blank lines, and the start and end tags of the block
    #            should not be indented with tabs or spaces. '
    result = <<-EOF
@@ -124,9 +127,10 @@ class YouTube < Liquid::Tag
 </div>
 
 EOF
-  Cache[@id] = result
-  return result
 
+    Cache[@id] = result
+
+    return result
 
   end
 

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -80,8 +80,10 @@ class YouTube < Liquid::Tag
     video = Yt::Video.new id: @id
 
     # extract the title and description
-    @title = video.title
-    @description = video.description
+    @video_data = {
+      'title' => video.title,
+      'description' => video.description
+    }
 
     puts " title #{@title}"
 
@@ -104,7 +106,7 @@ class YouTube < Liquid::Tag
    # note: so special care is required to produce html code that will not be massage by the 
    #       markdown processor :
    #       extract from the markdown doc :  
-   #           'The only restrictions are that block-level HTML elements ¿ e.g. <div>, <table>, <pre>, <p>, etc. 
+   #           'The only restrictions are that block-level HTML elements Â¿ e.g. <div>, <table>, <pre>, <p>, etc. 
    #            must be separated from surrounding content by blank lines, and the start and end tags of the block
    #            should not be indented with tabs or spaces. '
    result = <<-EOF

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -91,10 +91,9 @@ class YouTube < Liquid::Tag
       end
     end
 
+    @style = "width:100%;height:100%;background:#000 url(https://i2.ytimg.com/vi/#{@id}/0.jpg) center center no-repeat;background-size:contain;position:absolute"
 
-    @style = "width:100%;height:100%;background:#000 url(http://i2.ytimg.com/vi/#{@id}/0.jpg) center center no-repeat;background-size:contain;position:absolute" 
-    
-    @emu = "http://www.youtube.com/embed/#{@id}?autoplay=1"
+    @emu = "https://www.youtube.com/embed/#{@id}?autoplay=1"
 
     @videoFrame =  CGI.escapeHTML("<iframe style=\"vertical-align:top;width:100%;height:100%;position:absolute;\" src=\"#{@emu}\" frameborder=\"0\" allowfullscreen></iframe>")
  
@@ -117,7 +116,7 @@ class YouTube < Liquid::Tag
    result = <<-EOF
 
 <div class="ratio-4-3 embed-video-container" onclick="#{@onclick}" title="click here to play">
-<a class="youtube-lazy-link" style="#{@style}" href="http://www.youtube.com/watch?v=#{@id}" id="#{@id}" onclick="return false;">
+<a class="youtube-lazy-link" style="#{@style}" href="https://www.youtube.com/watch?v=#{@id}" id="#{@id}" onclick="return false;">
 <div class="youtube-lazy-link-div"></div>
 <div class="youtube-lazy-link-info">#{@video_data['title']}</div>
 </a>

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -38,7 +38,7 @@ class YouTube < Liquid::Tag
   def initialize(tagName, markup, tokens)
     super
 
-    @cache_folder = ".jekyll-cache/youtube"
+    @cache_folder = '.jekyll-cache/youtube'
     Dir.mkdir(@cache_folder) unless File.exist?(@cache_folder)
 
     if markup =~ Syntax then

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -84,6 +84,11 @@ class YouTube < Liquid::Tag
         'description' => video.description
       }
       Jekyll.logger.info("[Youtube]", "#{@video_data['title']}")
+
+      # Cache the result in a file
+      File.open(@cache_file, "w") do |f|
+        f.write(@video_data.to_json)
+      end
     end
 
 

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -65,9 +65,8 @@ class YouTube < Liquid::Tag
 
     @cache_file = File.join(@cache_folder, Digest::MD5.hexdigest("#{@id}"))
     if (File.exists?(@cache_file))
-      result = File.read(@cache_file)
-      Cache[@id] = result
-      return result
+      @video_data = JSON.parse(File.read(@cache_file))
+      Jekyll.logger.info("[Youtube]", "#{@video_data['title']} (cached)")
     end
 
     site = context.registers[:site]

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -67,8 +67,7 @@ class YouTube < Liquid::Tag
     if (File.exists?(@cache_file))
       @video_data = JSON.parse(File.read(@cache_file))
       Jekyll.logger.info("[Youtube]", "#{@video_data['title']} (cached)")
-    end
-
+    else
     site = context.registers[:site]
     settings = site.config['youtube']
     api_key = settings['api_key']
@@ -85,6 +84,7 @@ class YouTube < Liquid::Tag
       'description' => video.description
     }
     Jekyll.logger.info("[Youtube]", "#{@video_data['title']}")
+    end
 
 
     @style = "width:100%;height:100%;background:#000 url(http://i2.ytimg.com/vi/#{@id}/0.jpg) center center no-repeat;background-size:contain;position:absolute" 

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -68,22 +68,22 @@ class YouTube < Liquid::Tag
       @video_data = JSON.parse(File.read(@cache_file))
       Jekyll.logger.info("[Youtube]", "#{@video_data['title']} (cached)")
     else
-    site = context.registers[:site]
-    settings = site.config['youtube']
-    api_key = settings['api_key']
+      site = context.registers[:site]
+      settings = site.config['youtube']
+      api_key = settings['api_key']
 
-    Yt.configure do |config|
-      config.api_key = api_key
-    end
+      Yt.configure do |config|
+        config.api_key = api_key
+      end
 
-    video = Yt::Video.new id: @id
+      video = Yt::Video.new id: @id
 
-    # extract the title and description
-    @video_data = {
-      'title' => video.title,
-      'description' => video.description
-    }
-    Jekyll.logger.info("[Youtube]", "#{@video_data['title']}")
+      # extract the title and description
+      @video_data = {
+        'title' => video.title,
+        'description' => video.description
+      }
+      Jekyll.logger.info("[Youtube]", "#{@video_data['title']}")
     end
 
 

--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -119,9 +119,9 @@ class YouTube < Liquid::Tag
 <div class="ratio-4-3 embed-video-container" onclick="#{@onclick}" title="click here to play">
 <a class="youtube-lazy-link" style="#{@style}" href="http://www.youtube.com/watch?v=#{@id}" id="#{@id}" onclick="return false;">
 <div class="youtube-lazy-link-div"></div>
-<div class="youtube-lazy-link-info">#{@title}</div>
+<div class="youtube-lazy-link-info">#{@video_data['title']}</div>
 </a>
-<div class="video-info" >#{@description}</div>
+<div class="video-info" >#{@video_data['description']}</div>
 </div>
 
 EOF


### PR DESCRIPTION
This PR adds a cache to the plugin, so that calls to Youtube's API are only necessary for new videos.

It also speeds up the site generation.